### PR TITLE
[1.12] Support for custom render chunk implementations

### DIFF
--- a/src/main/java/lumien/chunkanimator/handler/AsmHandler.java
+++ b/src/main/java/lumien/chunkanimator/handler/AsmHandler.java
@@ -8,7 +8,7 @@ public class AsmHandler
 {
 	public static void preRenderChunk(RenderChunk renderChunk)
 	{
-		ChunkAnimator.INSTANCE.animationHandler.preRender(renderChunk);
+		ChunkAnimator.INSTANCE.animationHandler.preRender(renderChunk, renderChunk.getPosition());
 	}
 
 	public static void setOrigin(RenderChunk renderChunk, int oX, int oY, int oZ)


### PR DESCRIPTION
I'm the developer of Nothirium (a 1.12 mod similar to Sodium) and I would like to add compatibility with the Chunk Animator mod. But the `AnimationHandler` class only works with objects that extend the vanilla `RenderChunk` class and Nothirium uses it's own chunk rendering system which doesn't rely on vanilla classes.

That means currently the only way to add compatibility between Nothirium and Chunk Animator that I see is to copy the `AnimationHandler` class.
With this PR the `AnimationHandler` class works with all kinds of objects and not just vanilla render chunks. This would make adding compatibility a lot easier.